### PR TITLE
vm: add Jovian instruction set with custom gas costs for Base

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -413,6 +413,52 @@ func gasCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize
 	return gas, nil
 }
 
+const CallNewAccountGasJovianBase = 509_100
+
+// A copy of gasCall that uses the Jovian gas costs for CALL when a new account is created.
+func gasCallJovianBase(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+	var (
+		gas            uint64
+		transfersValue = !stack.Back(2).IsZero()
+		address        = common.Address(stack.Back(1).Bytes20())
+	)
+	if evm.chainRules.IsEIP158 {
+		if transfersValue && evm.StateDB.Empty(address) {
+			gas += CallNewAccountGasJovianBase
+		}
+	} else if !evm.StateDB.Exist(address) {
+		gas += CallNewAccountGasJovianBase
+	}
+	if transfersValue && !evm.chainRules.IsEIP4762 {
+		gas += params.CallValueTransferGas
+	}
+	memoryGas, err := memoryGasCost(mem, memorySize)
+	if err != nil {
+		return 0, err
+	}
+	var overflow bool
+	if gas, overflow = math.SafeAdd(gas, memoryGas); overflow {
+		return 0, ErrGasUintOverflow
+	}
+	if evm.chainRules.IsEIP4762 && !contract.IsSystemCall {
+		if transfersValue {
+			gas, overflow = math.SafeAdd(gas, evm.AccessEvents.ValueTransferGas(contract.Address(), address))
+			if overflow {
+				return 0, ErrGasUintOverflow
+			}
+		}
+	}
+	evm.callGasTemp, err = callGas(evm.chainRules.IsEIP150, contract.Gas, gas, stack.Back(0))
+	if err != nil {
+		return 0, err
+	}
+	if gas, overflow = math.SafeAdd(gas, evm.callGasTemp); overflow {
+		return 0, ErrGasUintOverflow
+	}
+
+	return gas, nil
+}
+
 func gasCallCode(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	memoryGas, err := memoryGasCost(mem, memorySize)
 	if err != nil {

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -115,6 +115,8 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	// If jump table was not initialised we set the default one.
 	var table *JumpTable
 	switch {
+	case evm.chainRules.IsOptimismJovian && evm.chainRules.IsOptimismBase:
+		table = &jovianInstructionSetForBase
 	case evm.chainRules.IsVerkle:
 		// TODO replace with proper instruction set when fork is specified
 		table = &verkleInstructionSet

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -63,6 +63,7 @@ var (
 	verkleInstructionSet           = newVerkleInstructionSet()
 	pragueInstructionSet           = newPragueInstructionSet()
 	eofInstructionSet              = newEOFInstructionSetForTesting()
+	jovianInstructionSetForBase    = newJovianInstructionSetForBase()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
@@ -99,6 +100,24 @@ func NewEOFInstructionSetForTesting() JumpTable {
 func newEOFInstructionSetForTesting() JumpTable {
 	instructionSet := newPragueInstructionSet()
 	enableEOF(&instructionSet)
+	return validate(instructionSet)
+}
+
+func newJovianInstructionSetForBase() JumpTable {
+	instructionSet := newPragueInstructionSet()
+
+	createOp := *instructionSet[CREATE]
+	createOp.constantGas = 480_000
+	instructionSet[CREATE] = &createOp
+
+	create2Op := *instructionSet[CREATE2]
+	create2Op.constantGas = 480_000
+	instructionSet[CREATE2] = &create2Op
+
+	callOp := *instructionSet[CALL]
+	callOp.dynamicGas = gasCallJovianBase
+	instructionSet[CALL] = &callOp
+
 	return validate(instructionSet)
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -1311,7 +1311,8 @@ type Rules struct {
 	IsOptimismBedrock, IsOptimismRegolith                   bool
 	IsOptimismCanyon, IsOptimismFjord                       bool
 	IsOptimismGranite, IsOptimismHolocene                   bool
-	IsOptimismIsthmus                                       bool
+	IsOptimismIsthmus, IsOptimismJovian                     bool
+	IsOptimismBase                                          bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -1351,6 +1352,8 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		IsOptimismGranite:  isMerge && c.IsOptimismGranite(timestamp),
 		IsOptimismHolocene: isMerge && c.IsOptimismHolocene(timestamp),
 		IsOptimismIsthmus:  isMerge && c.IsOptimismIsthmus(timestamp),
+		IsOptimismJovian:   isMerge && c.IsOptimismJovian(timestamp),
+		IsOptimismBase:     isMerge && (c.ChainID == new(big.Int).SetUint64(8453) || c.ChainID == new(big.Int).SetUint64(84532)),
 	}
 }
 


### PR DESCRIPTION
Implements a new Jovian instruction set specifically for Base chain with modified gas costs:
- CREATE/CREATE2 operations: 480,000 gas (increased from default)
- CALL operations: Uses gasCallJovianBase with 509,100 gas for new account creation

The instruction set is activated when both IsOptimismJovian and IsOptimismBase are true.